### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ WORKDIR /cmdstan
 RUN apt-get update
 RUN apt-get install --no-install-recommends -qq wget ca-certificates make g++
 
-RUN wget --progress=dot:mega https://github.com/stan-dev/cmdstan/releases/download/v2.20.0/cmdstan-2.20.0.tar.gz
-RUN tar -zxpf cmdstan-2.20.0.tar.gz
-RUN ln -s cmdstan-2.20.0 cmdstan
+RUN wget --progress=dot:mega https://github.com/stan-dev/cmdstan/releases/download/v2.27.0/cmdstan-2.27.0.tar.gz
+RUN tar -zxpf cmdstan-2.27.0.tar.gz
+RUN ln -s cmdstan-2.27.0 cmdstan
 RUN cd cmdstan; make build
 
 RUN cd cmdstan; echo "CmdStan home directory is" $PWD


### PR DESCRIPTION
v2.20.0 was momentous, but also the first build that defaulted to StanC3 and it had some bugs. Proposing an update to the release from last week.